### PR TITLE
Bayestar implementation, updates to classify_direct, and slight changes to batch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ The CLI also makes parallel processing easy. First generate a list of batch scri
 ```bash
 isoclassify batch direct examples/example.csv -o output > isoclassify.tot
 chmod +x isoclassify.tot
-parallel ::: isoclassify.tot
+parallel < isoclassify.tot
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ git clone https://github.com/danxhuber/isoclassify
 # Download dependencies
 pip install ebfpy 
 pip install ephem
+pip install dustmaps
 
 # Download MESA models into isoclassify directory
 cd isoclassify
@@ -26,6 +27,7 @@ wget https://www.dropbox.com/s/xrwwhgdgrhwgms7/grid_interp2.ebf?dl=0
 # Set environment variables
 export ISOCLASSIFY=${WKDIR}/code/isoclassify # access mesa models via ${ISOCLASSIFY}/mesa.ebf 
 export PYTHONPATH=${PYTHONPATH}:${ISOCLASSIFY}
+export PATH=${WKDIR}/code/isoclassify/bin:$PATH # This adds isoclassify executable to your path
 ```
 
 ## Grid Modeling:
@@ -66,10 +68,11 @@ mkdir -p output/sol # make sure output directory exists
 isoclassify run direct sol --csv examples/example.csv --outdir output/sol
 ```
 
-The CLI also makes parallel processing easy. First generate a list of batch scripts, then run using GNU parallel
+The CLI also makes parallel processing easy. First generate a list of batch scripts (isoclassify.tot), make isoclassify.tot an executable, then run using GNU parallel
 
 ```bash
 isoclassify batch direct examples/example.csv -o output > isoclassify.tot
+chmod +x isoclassify.tot
 parallel ::: isoclassify.tot
 ```
 

--- a/bin/isoclassify
+++ b/bin/isoclassify
@@ -35,6 +35,7 @@ def run(args):
 
 def batch(args):
     df = pd.read_csv(args.csv,engine='python')
+    print "#!/bin/sh"
     for i, row in df.iterrows():
         fmt = dict(**row)
         fmt = dict(fmt,**vars(args))

--- a/direct/classify_direct.py
+++ b/direct/classify_direct.py
@@ -264,7 +264,7 @@ def stparas(input,dnumodel=-99,bcmodel=-99,dustmodel=-99,dnucor=-99,useav=-99,pl
         out.plx=input.plx
         out.plxe=input.plxe
 
-        if (plot == 1):
+        if (plot == 1): # For interactive plotting
             plt.ion()
             plt.clf()
             plt.subplot(3,2,1)
@@ -290,7 +290,34 @@ def stparas(input,dnumodel=-99,bcmodel=-99,dustmodel=-99,dnucor=-99,useav=-99,pl
             plt.subplot(3,2,6)
             plt.hist(avs,bins=100)
             plt.title('Av')
-            plt.tight_layout() # To prevent overlap in plots
+            plt.tight_layout()
+            raw_input(':')
+        
+        if (plot == 0): # For non-interactive plotting. Any other number for no plotting at all.
+            plt.clf()
+            plt.subplot(3,2,1)
+            plt.hist(teffsamp,bins=100)
+            plt.title('Teff')
+
+            plt.subplot(3,2,2)
+            plt.hist(lum,bins=100)
+            plt.title('Lum')
+
+            plt.subplot(3,2,3)
+            plt.hist(rad,bins=100)
+            plt.title('Rad')
+
+            plt.subplot(3,2,4)
+            plt.hist(absmag,bins=100)
+            plt.title('absmag')
+
+            plt.subplot(3,2,5)
+            plt.hist(dsamp,bins=100)
+            plt.title('distance')
+
+            plt.subplot(3,2,6)
+            plt.hist(avs,bins=100)
+            plt.title('Av')
 
 
         print '   '
@@ -301,8 +328,6 @@ def stparas(input,dnumodel=-99,bcmodel=-99,dustmodel=-99,dnucor=-99,useav=-99,pl
         print 'lum(lsun):',out.lum,'+',out.lumep,'-',out.lumem
         
         print '-----'
-        if (plot == 1):
-            raw_input(':')
 
     ##############################################
     # case 2: input is spectroscopy + seismology #

--- a/direct/classify_direct.py
+++ b/direct/classify_direct.py
@@ -264,7 +264,7 @@ def stparas(input,dnumodel=-99,bcmodel=-99,dustmodel=-99,dnucor=-99,useav=-99,pl
         out.plx=input.plx
         out.plxe=input.plxe
 
-        if (plot == 1): # For interactive plotting
+        if (plot == 'i'): # For interactive plotting
             plt.ion()
             plt.clf()
             plt.subplot(3,2,1)
@@ -293,7 +293,7 @@ def stparas(input,dnumodel=-99,bcmodel=-99,dustmodel=-99,dnucor=-99,useav=-99,pl
             plt.tight_layout()
             raw_input(':')
         
-        if (plot == 0): # For non-interactive plotting. Any other number for no plotting at all.
+        if (plot == 1): # For non-interactive plotting. Any other number for no plotting at all.
             plt.clf()
             plt.subplot(3,2,1)
             plt.hist(teffsamp,bins=100)

--- a/direct/classify_direct.py
+++ b/direct/classify_direct.py
@@ -3,12 +3,11 @@
 # corrections
 
 import numpy as np
-# import asfgrid
-import h5py 
-import ephem
+import pdb
+import astropy.units as units
 from scipy.interpolate import RegularGridInterpolator
 import matplotlib.pyplot as plt
-import pdb
+from astropy.coordinates import SkyCoord
 
 def stparas(input,dnumodel=-99,bcmodel=-99,dustmodel=-99,dnucor=-99,useav=-99,plot=-99,band='k'):
 
@@ -49,13 +48,13 @@ def stparas(input,dnumodel=-99,bcmodel=-99,dustmodel=-99,dnucor=-99,useav=-99,pl
     logggrid = bcmodel['logggrid'][:]
     fehgrid = bcmodel['fehgrid'][:]
     avgrid = bcmodel['avgrid'][:]
-    bc_k = bcmodel['bc_'+band][:]
+    bc_band = bcmodel['bc_'+band][:]
 
     if ((input.plx > 0.)):
         # load up bolometric correction grid
         # only K-band for now
         points = (teffgrid,logggrid,fehgrid,avgrid)
-        values = bc_k
+        values = bc_band
         interp = RegularGridInterpolator(points,values)
 
         ### Monte Carlo starts here
@@ -457,7 +456,7 @@ def stparas(input,dnumodel=-99,bcmodel=-99,dustmodel=-99,dnucor=-99,useav=-99,pl
                 # bolometric correction interpolated from MESA
 
                 points = (teffgrid,logggrid,fehgrid,avgrid)
-                values = bc_k
+                values = bc_band
                 interp = RegularGridInterpolator(points, values)
 
                 #pdb.set_trace()

--- a/examples/example.csv
+++ b/examples/example.csv
@@ -1,4 +1,4 @@
-id_starname,teff,teff_err,logg,logg_err,feh,feh_err,parallax,parallax_err,kmag,kmag_err,comments
-sol,5770,70,4.44,0.07,0,0.04,0.1,0.001,3.302,0.01,should return 1 solar radius
-K2-3,3825,70,4.7,1,-0.27,0.09,0.022661,5.53E-05,8.561,0.023,using very loose logg constraints
-K2-24,5625,100,4.29,0.08,0.34,0.04,0.005835,0.000046,9.18,0.021,
+id_starname,teff,teff_err,logg,logg_err,feh,feh_err,parallax,parallax_err,kmag,kmag_err,comments,ra,dec
+sol,5770,70,4.44,0.07,0,0.04,0.1,0.001,3.302,0.01,should return 1 solar radius,290.1122,44.6
+K2-3,3825,70,4.7,1,-0.27,0.09,0.022661,5.53E-05,8.561,0.023,using very loose logg constraints,172.3349550,-1.4547870
+K2-24,5625,100,4.29,0.08,0.34,0.04,0.005835,0.000046,9.18,0.021,,242.5737150,-24.9903310

--- a/isoclassify.py
+++ b/isoclassify.py
@@ -1,12 +1,16 @@
 import os 
 import copy
 import glob
+import pdb
+import h5py
 
 import numpy as np
 from matplotlib import pylab as plt
 import pandas as pd
 import ebf
-import mwdust 
+import astropy.units as units
+from astropy.coordinates import SkyCoord
+from dustmaps.bayestar import BayestarWebQuery
 
 import grid.classify_grid 
 import direct.classify_direct 
@@ -33,6 +37,20 @@ def run(**kw):
 def load_mist():
     return model
 
+def query_dustmodel_coords(ra,dec):
+    reddenMap = BayestarWebQuery(version='bayestar2017')
+    sightLines = SkyCoord(ra*units.deg,dec*units.deg,frame='icrs')
+    reddenContainer = reddenMap(sightLines,mode='random_sample')
+    del reddenMap # To clear reddenMap from memory
+    distanceSamples = np.array([0.06309573,0.07943284,0.1,0.12589255,0.15848933,0.19952627,0.25118864,0.31622776,0.3981072,0.50118726,0.6309574,0.7943282 ,1.,1.2589258,1.5848933,1.9952621,2.511887,3.1622777,3.981073,5.011873,6.3095727,7.943284,10.,12.589258,15.848933,19.952621,25.11887,31.622776,39.81073,50.11873,63.095726])*1000. # In pc, from bayestar2017 map distance samples
+    
+    dustModelDF = pd.DataFrame({'ra': [ra], 'dec': [dec]})
+    
+    for index in xrange(len(reddenContainer)):
+        dustModelDF['av_'+str(round(distanceSamples[index],6))] = reddenContainer[index]
+
+    return dustModelDF
+
 class Pipeline(object):
     def __init__(self, **kw):
         self.id_starname = kw['id_starname']
@@ -53,7 +71,9 @@ class Pipeline(object):
                 const[key+'_err'] = 0
 
         self.const = const
-        self.pngfn = os.path.join(self.outdir,'output.png')
+        self.const['ra'] = star['ra']
+        self.const['dec'] = star['dec']
+        self.pdffn = os.path.join(self.outdir,'output.pdf')
         self.csvfn = os.path.join(self.outdir,'output.csv')
 
     def addspec(self,x):
@@ -76,6 +96,12 @@ class Pipeline(object):
 
     def addplx(self,x):
         x.addplx(self.const['parallax'], self.const['parallax_err'])
+    
+    def addcoords(self,x):
+        x.addcoords(self.const['ra'],self.const['dec'])
+    
+    def addmag(self,x):
+        x.addmag([self.const['kmag']],[self.const['kmag_err']])
 
     def print_constraints(self):
         print "id_starname {}".format(self.id_starname)
@@ -85,7 +111,7 @@ class Pipeline(object):
     def savefig(self):
         fig = plt.gcf()
         fig.set_tight_layout(True)
-        plt.savefig(self.pngfn)
+        plt.savefig(self.pdffn)
 
     def to_csv(self):
         out = {}
@@ -118,24 +144,25 @@ class Pipeline(object):
 
 class PipelineDirect(Pipeline):
     outputcols = {
-        'iso_dis': 'dis',
-        'iso_avs': 'avs',
-        'iso_rad': 'rad',
-        'iso_lum': 'lum',
+        'dir_dis': 'dis',
+        'dir_avs': 'avs',
+        'dir_rad': 'rad',
+        'dir_lum': 'lum',
     }
-
+    
     def run(self):
         self.print_constraints()
-        bcmodel = '/Users/petigura/code/isoclassify/direct/bcgrid.h5'
-        dustmodel = mwdust.Combined15()
+        bcmodel = h5py.File('/Users/taberger/Astronomy/Thesis/Codebase/isoclassify/direct/bcgrid.h5','r',driver='core',backing_store=False)
+        dustmodel = query_dustmodel_coords(self.const['ra'],self.const['dec'])
 
         x = direct.classify_direct.obsdata()
         self.addspec(x)
         self.addjhk(x)
-        self.addgriz(x)
         self.addplx(x)
+        self.addcoords(x)
+        self.addmag(x)
         self.paras = direct.classify_direct.stparas(
-            input=x,bcmodel=bcmodel,dustmodel=dustmodel,useav=0,plot=1
+            input=x,bcmodel=bcmodel,dustmodel=dustmodel,band='k',plot=0
         )
 
 

--- a/isoclassify.py
+++ b/isoclassify.py
@@ -162,7 +162,7 @@ class PipelineDirect(Pipeline):
         self.addcoords(x)
         self.addmag(x)
         self.paras = direct.classify_direct.stparas(
-            input=x,bcmodel=bcmodel,dustmodel=dustmodel,band='k',plot=0
+            input=x,bcmodel=bcmodel,dustmodel=dustmodel,band='k',plot=1
         )
 
 


### PR DESCRIPTION
isoclassify/direct now includes the ability to query the bayestar2017 package for reddening. This works  by using BayestarWebQuery to query the star's ra and dec and returns a random sample of reddening from the map to simulate errors in the map itself at a variety of distances. This produces a pandas df with reddening at each of the sample distances, which we then interpolate based on the PDF of the sample distances computed within classify_direct.

In addition, I updated the implementation of maxds and minds in classify_direct and added the option to plot interactively with 'i" and non-interactive plotting with 1. The commit messages should cover everything else.