### PR TITLE
Add version number to package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Python codes to perform stellar classifications given any set of input observabl
 
 1. Download `mwdust` (see https://github.com/jobovy/mwdust).
 
-2. Clone and `cd` to the repo,
+2. Clone and `cd` to the repo (do this outside of your python `site-packages` directory, e.g. your home directory),
 
     ```bash
     git clone https://github.com/danxhuber/isoclassify

--- a/isoclassify/__init__.py
+++ b/isoclassify/__init__.py
@@ -1,4 +1,7 @@
 import os
+import importlib.metadata
+
+__version__ = importlib.metadata.version(__package__)  # only works if package installed via pip
 
 # Absolute path to the package directory
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scipy
 h5py
 joblib
 pandas
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
 import os
 from setuptools import setup
 
-# Load version
-__version__ = None
-# exec(open('isoclassify/version.py').read())
+# Set version (increment this when making a new release)
+version = "1.2"
 
 # Load requirements
 requirements = None
@@ -31,7 +30,7 @@ desc = 'Python codes to perform stellar classifications given any set of input o
 
 setup(
     name='isoclassify',
-    version=__version__,
+    version=version,
     description=desc,
     package_dir={
         'isoclassify': 'isoclassify', 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup
 
 # Set version (increment this when making a new release)
-version = "1.2"
+version = "1.2.1"
 
 # Load requirements
 requirements = None


### PR DESCRIPTION
Solves Issue #39. 

* Add version number to package
* Add `__version__` to package `__init__.py`. This automatically pulls from package metadata configured in `setup.py`.

If/when new version is released, the `version` variable in `setup.py` should be updated to match the release version.

I have incremented version to "1.2.1" so that a new release can contain this fix.
